### PR TITLE
Updated bat script and Python version required

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -6,7 +6,7 @@ These steps will guide you on how to setup a new work client. The nano-work-serv
 
 ### Requirements
 
-1. [Python](https://www.python.org/) 3.6.7 or higher.
+1. [Python](https://www.python.org/) 3.6.7 or higher up to 3.8.6.
 
 ### Installation
 

--- a/client/run_windows.bat
+++ b/client/run_windows.bat
@@ -34,12 +34,17 @@ timeout %start_delay_seconds%
 
 echo.
 echo Starting BoomPow Client...
+if %payout_address% == "ban_1boompow14irck1yauquqypt7afqrh8b6bbu5r93pc6hgbqs7z6o99frcuym" (
+	echo [91mERROR: Payout address is not configured. Please configure your payout address.[0m
+	timeout 30
+	exit
+)
 if %async_mode% (
     if %limit_logging% (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --async_mode --limit-logging
-    ) else {
+    ) else (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --async_mode
-    }
+    )
 ) else (
     if %limit_logging% (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --limit-logging


### PR DESCRIPTION
There was a slight syntactical mistake inside bat script. Additionally I added the line to check if default payout address is changed. If not, the script will throw the error at the user and exit.

In README.md file, Python versions specified are updated, since there is known bug that Python 3.9.0 and higher does not work with boompow at this time. So versions required are updated to 3.6.7 and higher up to 3.8.6 (the last known version to work with boompow).