### PR TITLE
Fixed brackets in run_windows.bat

### DIFF
--- a/client/run_windows.bat
+++ b/client/run_windows.bat
@@ -37,9 +37,9 @@ echo Starting BoomPow Client...
 if %async_mode% (
     if %limit_logging% (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --async_mode --limit-logging
-    ) else {
+    ) else (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --async_mode
-    }
+    )
 ) else (
     if %limit_logging% (
         python bpow_client.py --payout %payout_address% --work %desired_work_type% --limit-logging


### PR DESCRIPTION
running this file threw the error: '{' is not recognized as an internal or external command, operable program or batch file
https://imgur.com/a/zVo1gBb