### PR TITLE
Warning about Python 3.10

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -8,6 +8,7 @@ These steps will guide you on how to setup a new work client. The nano-work-serv
 
 1. [Python](https://www.python.org/) 3.6.7 or higher.
 
+Note that there are compatability issues with Python 3.10.1 currently. 
 ### Installation
 
 - Download the [latest version](https://github.com/bbedward/boompow/releases) and extract it.


### PR DESCRIPTION
Per https://discord.com/channels/415935345075421194/626058996578648065/919235063655317544 the current implementation uses some features deprecated in Python 3.10 (asyncio.get_event_loop()) to be more exact. 

Additionally, it appears that MQTT also is not 3.10 compatible, thus my attempted patch didn't work.